### PR TITLE
カラーコード 0 が無い & 16 が不要

### DIFF
--- a/app/assets/stylesheets/irc_color.css
+++ b/app/assets/stylesheets/irc_color.css
@@ -1,3 +1,4 @@
+.irc_color_0{ color:white }
 .irc_color_1{ color:black }
 .irc_color_2{ color:navy }
 .irc_color_3{ color:green }
@@ -13,4 +14,3 @@
 .irc_color_13{ color:pink }
 .irc_color_14{ color:darkgray }
 .irc_color_15{ color:lightgrey }
-.irc_color_16{ color:white }


### PR DESCRIPTION
- [mIRC Colors](http://www.mirc.co.uk/colors.html)

> 0 white
> 1 black
> 2 blue (navy)
> 3 green
> 4 red
> 5 brown (maroon)
> 6 purple
> 7 orange (olive)
> 8 yellow
> 9 light green (lime)
> 10 teal (a green/blue cyan)
> 11 light cyan (cyan) (aqua)
> 12 light blue (royal)
> 13 pink (light purple) (fuchsia)
> 14 grey
> 15 light grey (silver)

たぶん [tiarraMetro の CSS](https://github.com/tyoro/tiarraMetro/blob/master/public/css/style.css#L510) を参考にしたんだろうけど、それが間違ってる。
